### PR TITLE
feat: improve markdown rendering and image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,32 @@
 # Clotho
 
-A desktop application built with Tauri 2, React 19, and TypeScript.
+A task management desktop application built with Tauri 2, React 19, and TypeScript.
+
+## Features
+
+- **Project & Task Management**: Organize tasks into projects with status, priority, and scheduling
+- **Rich Text Descriptions**: Markdown editor with slash commands, code blocks, and image support
+- **Image Attachments**: Attach images to tasks, served via efficient custom protocol (`clotho://`)
+- **Tags & Filtering**: Categorize tasks with colored tags
+- **MCP Server**: Built-in Model Context Protocol server for AI assistant integration
 
 ## Tech Stack
 
-- **Framework**: [Tauri 2](https://tauri.app/) - Build desktop apps with web technologies
+- **Framework**: [Tauri 2](https://tauri.app/) - Desktop apps with Rust backend
 - **Frontend**: [React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
 - **Styling**: [Tailwind CSS 4](https://tailwindcss.com/)
 - **Routing**: [TanStack Router](https://tanstack.com/router)
-- **Rich Text Editor**: [Tiptap](https://tiptap.dev/)
-- **State Management**: [Zustand](https://zustand-demo.pmnd.rs/)
-- **UI Components**: [Radix UI](https://www.radix-ui.com/) + [shadcn/ui](https://ui.shadcn.com/)
-- **Build Tool**: [Vite 7](https://vitejs.dev/)
+- **Rich Text**: [Tiptap](https://tiptap.dev/) with Markdown support
+- **State**: [Zustand](https://zustand-demo.pmnd.rs/)
+- **UI**: [Radix UI](https://www.radix-ui.com/) + [shadcn/ui](https://ui.shadcn.com/)
+- **Database**: SQLite (rusqlite)
+- **Build**: [Vite 7](https://vitejs.dev/)
 
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) (v18+)
 - [pnpm](https://pnpm.io/) (v10+)
-- [Rust](https://www.rust-lang.org/) (for Tauri)
+- [Rust](https://www.rust-lang.org/) (for Tauri backend)
 
 ## Getting Started
 
@@ -31,6 +40,22 @@ pnpm tauri dev
 # Build for production
 pnpm tauri build
 ```
+
+## Architecture
+
+### Image Handling
+
+Images attached to tasks are served via a custom `clotho://` protocol:
+- `clotho://image/{id}` - Returns binary image data directly
+- Supports browser caching with immutable Cache-Control headers
+- No base64 encoding overhead
+
+### MCP Server
+
+The built-in MCP server allows AI assistants to manage tasks:
+- Endpoint: `http://localhost:7400/mcp` (configurable)
+- Enable in Settings > MCP Server
+- Supports task/project/tag CRUD operations
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-router": "^1.163.3",
     "@tanstack/react-table": "^8.21.3",
@@ -23,7 +24,6 @@
     "@tiptap/extension-image": "^3.20.0",
     "@tiptap/extension-link": "^3.20.0",
     "@tiptap/extension-placeholder": "^3.20.0",
-    "@tiptap/markdown": "^3.20.0",
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",
@@ -35,6 +35,8 @@
     "lowlight": "^3.3.0",
     "lucide-react": "^0.575.0",
     "next-themes": "^0.4.6",
+    "prosemirror-markdown": "^1.13.4",
+    "prosemirror-model": "^1.25.4",
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-day-picker": "^9.14.0",
@@ -42,6 +44,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
+    "tiptap-markdown": "^0.9.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.2.1)
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))
@@ -47,9 +50,6 @@ importers:
       '@tiptap/extension-placeholder':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/extensions@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))
-      '@tiptap/markdown':
-        specifier: ^3.20.0
-        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/pm':
         specifier: ^3.20.0
         version: 3.20.0
@@ -83,6 +83,12 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      prosemirror-markdown:
+        specifier: ^1.13.4
+        version: 1.13.4
+      prosemirror-model:
+        specifier: ^1.25.4
+        version: 1.25.4
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -104,6 +110,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
+      tiptap-markdown:
+        specifier: ^0.9.0
+        version: 0.9.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(immer@10.2.0)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -1524,6 +1533,11 @@ packages:
     resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
     engines: {node: '>= 20'}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
@@ -1798,12 +1812,6 @@ packages:
       '@tiptap/core': ^3.20.0
       '@tiptap/pm': ^3.20.0
 
-  '@tiptap/markdown@3.20.0':
-    resolution: {integrity: sha512-3vUxs8tsVIf/KWKLWjFsTqrjuaTYJY9rawDL5sio9NwlqFWDuWpHEVJcqbQXJUrgQSh12AZoTKyfgiEqkAGI3Q==}
-    peerDependencies:
-      '@tiptap/core': ^3.20.0
-      '@tiptap/pm': ^3.20.0
-
   '@tiptap/pm@3.20.0':
     resolution: {integrity: sha512-jn+2KnQZn+b+VXr8EFOJKsnjVNaA4diAEr6FOazupMt8W8ro1hfpYtZ25JL87Kao/WbMze55sd8M8BDXLUKu1A==}
 
@@ -1847,11 +1855,20 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
+
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
@@ -2668,13 +2685,11 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
-    hasBin: true
-
-  marked@17.0.3:
-    resolution: {integrity: sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==}
-    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -2869,6 +2884,10 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -3232,6 +3251,11 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tiptap-markdown@0.9.0:
+    resolution: {integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.1
 
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
@@ -4800,6 +4824,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.1)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.1
+
   '@tailwindcss/vite@4.2.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
       '@tailwindcss/node': 4.2.1
@@ -5028,12 +5057,6 @@ snapshots:
       '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
 
-  '@tiptap/markdown@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)':
-    dependencies:
-      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
-      '@tiptap/pm': 3.20.0
-      marked: 17.0.3
-
   '@tiptap/pm@3.20.0':
     dependencies:
       prosemirror-changeset: 2.4.0
@@ -5137,12 +5160,21 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/linkify-it@3.0.5': {}
+
   '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
 
   '@types/markdown-it@14.1.2':
     dependencies:
       '@types/linkify-it': 5.0.0
       '@types/mdurl': 2.0.0
+
+  '@types/mdurl@1.0.5': {}
 
   '@types/mdurl@2.0.0': {}
 
@@ -5870,6 +5902,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it-task-lists@2.1.1: {}
+
   markdown-it@14.1.1:
     dependencies:
       argparse: 2.0.1
@@ -5878,8 +5912,6 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
-
-  marked@17.0.3: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -6052,6 +6084,11 @@ snapshots:
   picomatch@4.0.3: {}
 
   pkce-challenge@5.0.1: {}
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -6567,6 +6604,14 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tiptap-markdown@0.9.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0)):
+    dependencies:
+      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.1.1
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.4
 
   tldts-core@7.0.23: {}
 

--- a/src-tauri/src/commands/image.rs
+++ b/src-tauri/src/commands/image.rs
@@ -154,3 +154,37 @@ pub fn delete_task_image(
 
     Ok(())
 }
+
+#[tauri::command]
+pub fn get_task_image_by_filename(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    task_id: String,
+    filename: String,
+) -> Result<String, AppError> {
+    let db = lock_db(&state)?;
+
+    // Find image by task_id and filename (use the most recent one if duplicates exist)
+    let (id, stored_filename, _mime_type): (String, String, String) = db
+        .query_row(
+            "SELECT id, filename, mime_type FROM task_images WHERE task_id = ?1 AND filename = ?2 ORDER BY created_at DESC LIMIT 1",
+            rusqlite::params![&task_id, &filename],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => AppError::NotFound(format!("image {filename} in task {task_id}")),
+            other => AppError::Database(other),
+        })?;
+
+    // Determine stored filename (id.ext)
+    let ext = stored_filename.rsplit('.').next().unwrap_or("bin");
+    let disk_filename = format!("{}.{}", id, ext);
+    let dir = images_dir(&app)?;
+    let file_path = dir.join(&disk_filename);
+
+    let bytes = fs::read(&file_path).map_err(|e| {
+        AppError::NotFound(format!("image file not found: {e}"))
+    })?;
+
+    Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
+}

--- a/src-tauri/src/commands/image.rs
+++ b/src-tauri/src/commands/image.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::path::PathBuf;
-use base64::Engine;
 use tauri::{AppHandle, Manager, State};
 
 use crate::commands::lock_db;
@@ -65,38 +64,6 @@ pub fn upload_task_image(
 }
 
 #[tauri::command]
-pub fn get_task_image(
-    app: AppHandle,
-    state: State<'_, AppState>,
-    id: String,
-) -> Result<String, AppError> {
-    let db = lock_db(&state)?;
-
-    let (filename, _mime_type): (String, String) = db
-        .query_row(
-            "SELECT filename, mime_type FROM task_images WHERE id = ?1",
-            [&id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => AppError::NotFound(format!("image {id}")),
-            other => AppError::Database(other),
-        })?;
-
-    // Determine stored filename (id.ext)
-    let ext = filename.rsplit('.').next().unwrap_or("bin");
-    let stored_filename = format!("{}.{}", id, ext);
-    let dir = images_dir(&app)?;
-    let file_path = dir.join(&stored_filename);
-
-    let bytes = fs::read(&file_path).map_err(|e| {
-        AppError::NotFound(format!("image file not found: {e}"))
-    })?;
-
-    Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
-}
-
-#[tauri::command]
 pub fn list_task_images(
     state: State<'_, AppState>,
     task_id: String,
@@ -153,38 +120,4 @@ pub fn delete_task_image(
     let _ = fs::remove_file(&file_path);
 
     Ok(())
-}
-
-#[tauri::command]
-pub fn get_task_image_by_filename(
-    app: AppHandle,
-    state: State<'_, AppState>,
-    task_id: String,
-    filename: String,
-) -> Result<String, AppError> {
-    let db = lock_db(&state)?;
-
-    // Find image by task_id and filename (use the most recent one if duplicates exist)
-    let (id, stored_filename, _mime_type): (String, String, String) = db
-        .query_row(
-            "SELECT id, filename, mime_type FROM task_images WHERE task_id = ?1 AND filename = ?2 ORDER BY created_at DESC LIMIT 1",
-            rusqlite::params![&task_id, &filename],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => AppError::NotFound(format!("image {filename} in task {task_id}")),
-            other => AppError::Database(other),
-        })?;
-
-    // Determine stored filename (id.ext)
-    let ext = stored_filename.rsplit('.').next().unwrap_or("bin");
-    let disk_filename = format!("{}.{}", id, ext);
-    let dir = images_dir(&app)?;
-    let file_path = dir.join(&disk_filename);
-
-    let bytes = fs::read(&file_path).map_err(|e| {
-        AppError::NotFound(format!("image file not found: {e}"))
-    })?;
-
-    Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,7 +97,13 @@ pub fn run() {
             }; // conn guard dropped here, before file IO
 
             // Build file path: images/{id}.{ext}
-            let ext = filename.rsplit('.').next().unwrap_or("bin");
+            // Sanitize ext to prevent path traversal (only allow alphanumeric chars)
+            let raw_ext = filename.rsplit('.').next().unwrap_or("bin");
+            let sanitized_ext: String = raw_ext
+                .chars()
+                .filter(|c| c.is_ascii_alphanumeric())
+                .collect();
+            let ext = if sanitized_ext.is_empty() { "bin" } else { &sanitized_ext };
             let stored_filename = format!("{}.{}", image_id, ext);
 
             let images_dir = match app.path().app_data_dir() {
@@ -124,7 +130,12 @@ pub fn run() {
             };
 
             // Validate mime_type, fallback to application/octet-stream if invalid
-            let content_type = if mime_type.is_empty() || mime_type.contains('\0') {
+            // Reject empty, NUL, CR, LF to prevent header injection
+            let content_type = if mime_type.is_empty()
+                || mime_type.contains('\0')
+                || mime_type.contains('\r')
+                || mime_type.contains('\n')
+            {
                 "application/octet-stream".to_string()
             } else {
                 mime_type

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,6 +167,7 @@ pub fn run() {
             // image commands
             commands::image::upload_task_image,
             commands::image::get_task_image,
+            commands::image::get_task_image_by_filename,
             commands::image::list_task_images,
             commands::image::delete_task_image,
             // mcp

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,14 +134,14 @@ pub fn run() {
                 .status(200)
                 .header("Content-Type", content_type)
                 .header("Cache-Control", "max-age=31536000, immutable")
-                .body(bytes.clone())
+                .body(bytes)
             {
                 Ok(resp) => resp,
                 Err(_) => {
-                    // Fallback if header construction fails
+                    // Fallback if header construction fails (return empty body)
                     tauri::http::Response::builder()
-                        .status(200)
-                        .body(bytes)
+                        .status(500)
+                        .body(Vec::new())
                         .unwrap()
                 }
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,86 @@ fn load_mcp_settings(db: &rusqlite::Connection) -> (bool, String) {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .register_uri_scheme_protocol("clotho", |ctx, request| {
+            let uri = request.uri();
+            let host = uri.host().unwrap_or("");
+            let path = uri.path();
+
+            // Handle clotho://image/{image_id} where host="image" and path="/{image_id}"
+            if host != "image" {
+                return tauri::http::Response::builder()
+                    .status(404)
+                    .body(Vec::new())
+                    .unwrap();
+            }
+
+            // path is "/{image_id}", skip leading "/"
+            let image_id = path.trim_start_matches('/');
+
+            // Get database connection from state
+            let app = ctx.app_handle();
+            let state = app.state::<AppState>();
+            let conn = match state.db.lock() {
+                Ok(c) => c,
+                Err(_) => {
+                    return tauri::http::Response::builder()
+                        .status(500)
+                        .body(Vec::new())
+                        .unwrap();
+                }
+            };
+
+            // Query image metadata
+            let result: Result<(String, String), rusqlite::Error> = conn.query_row(
+                "SELECT filename, mime_type FROM task_images WHERE id = ?1",
+                [image_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            );
+
+            let (filename, mime_type) = match result {
+                Ok(data) => data,
+                Err(_) => {
+                    return tauri::http::Response::builder()
+                        .status(404)
+                        .body(Vec::new())
+                        .unwrap();
+                }
+            };
+
+            // Build file path: images/{id}.{ext}
+            let ext = filename.rsplit('.').next().unwrap_or("bin");
+            let stored_filename = format!("{}.{}", image_id, ext);
+
+            let images_dir = match app.path().app_data_dir() {
+                Ok(dir) => dir.join("images"),
+                Err(_) => {
+                    return tauri::http::Response::builder()
+                        .status(500)
+                        .body(Vec::new())
+                        .unwrap();
+                }
+            };
+
+            let file_path = images_dir.join(&stored_filename);
+
+            // Read file
+            let bytes = match std::fs::read(&file_path) {
+                Ok(b) => b,
+                Err(_) => {
+                    return tauri::http::Response::builder()
+                        .status(404)
+                        .body(Vec::new())
+                        .unwrap();
+                }
+            };
+
+            tauri::http::Response::builder()
+                .status(200)
+                .header("Content-Type", mime_type)
+                .header("Cache-Control", "max-age=31536000, immutable")
+                .body(bytes)
+                .unwrap()
+        })
         .setup(|app| {
             let app_data_dir = app
                 .path()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,12 +123,28 @@ pub fn run() {
                 }
             };
 
-            tauri::http::Response::builder()
+            // Validate mime_type, fallback to application/octet-stream if invalid
+            let content_type = if mime_type.is_empty() || mime_type.contains('\0') {
+                "application/octet-stream".to_string()
+            } else {
+                mime_type
+            };
+
+            match tauri::http::Response::builder()
                 .status(200)
-                .header("Content-Type", mime_type)
+                .header("Content-Type", content_type)
                 .header("Cache-Control", "max-age=31536000, immutable")
-                .body(bytes)
-                .unwrap()
+                .body(bytes.clone())
+            {
+                Ok(resp) => resp,
+                Err(_) => {
+                    // Fallback if header construction fails
+                    tauri::http::Response::builder()
+                        .status(200)
+                        .body(bytes)
+                        .unwrap()
+                }
+            }
         })
         .setup(|app| {
             let app_data_dir = app

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,35 +65,36 @@ pub fn run() {
             // path is "/{image_id}", skip leading "/"
             let image_id = path.trim_start_matches('/');
 
-            // Get database connection from state
+            // Query image metadata (limit lock scope to just the query)
             let app = ctx.app_handle();
-            let state = app.state::<AppState>();
-            let conn = match state.db.lock() {
-                Ok(c) => c,
-                Err(_) => {
-                    return tauri::http::Response::builder()
-                        .status(500)
-                        .body(Vec::new())
-                        .unwrap();
-                }
-            };
+            let (filename, mime_type) = {
+                let state = app.state::<AppState>();
+                let conn = match state.db.lock() {
+                    Ok(c) => c,
+                    Err(_) => {
+                        return tauri::http::Response::builder()
+                            .status(500)
+                            .body(Vec::new())
+                            .unwrap();
+                    }
+                };
 
-            // Query image metadata
-            let result: Result<(String, String), rusqlite::Error> = conn.query_row(
-                "SELECT filename, mime_type FROM task_images WHERE id = ?1",
-                [image_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            );
+                let result: Result<(String, String), rusqlite::Error> = conn.query_row(
+                    "SELECT filename, mime_type FROM task_images WHERE id = ?1",
+                    [image_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                );
 
-            let (filename, mime_type) = match result {
-                Ok(data) => data,
-                Err(_) => {
-                    return tauri::http::Response::builder()
-                        .status(404)
-                        .body(Vec::new())
-                        .unwrap();
+                match result {
+                    Ok(data) => data,
+                    Err(_) => {
+                        return tauri::http::Response::builder()
+                            .status(404)
+                            .body(Vec::new())
+                            .unwrap();
+                    }
                 }
-            };
+            }; // conn guard dropped here, before file IO
 
             // Build file path: images/{id}.{ext}
             let ext = filename.rsplit('.').next().unwrap_or("bin");
@@ -246,8 +247,6 @@ pub fn run() {
             commands::settings::update_settings,
             // image commands
             commands::image::upload_task_image,
-            commands::image::get_task_image,
-            commands::image::get_task_image_by_filename,
             commands::image::list_task_images,
             commands::image::delete_task_image,
             // mcp

--- a/src/components/common/RichTextEditor.tsx
+++ b/src/components/common/RichTextEditor.tsx
@@ -305,9 +305,10 @@ export function RichTextEditor({
       const target = e.target as HTMLElement;
       const link = target.closest('a');
       if (link) {
-        e.preventDefault();
         const href = link.getAttribute('href');
+        // Only handle http/https links; let other schemes (mailto:, #anchor, etc.) work normally
         if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+          e.preventDefault();
           openUrl(href).catch(() => {
             // Fallback for dev mode or if plugin fails
             window.open(href, '_blank', 'noopener,noreferrer');

--- a/src/components/common/RichTextEditor.tsx
+++ b/src/components/common/RichTextEditor.tsx
@@ -5,9 +5,18 @@ import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import Link from '@tiptap/extension-link';
 import Image from '@tiptap/extension-image';
-import { Markdown } from '@tiptap/markdown';
+import { Markdown, MarkdownStorage } from 'tiptap-markdown';
+import { defaultMarkdownSerializer, MarkdownSerializerState } from 'prosemirror-markdown';
+import { Node as PmNode } from 'prosemirror-model';
 import { cn } from '@/lib/utils';
 import { SlashMenu, SlashMenuExtension } from './SlashMenu';
+
+// Extend Tiptap Storage type to include markdown
+declare module '@tiptap/core' {
+  interface Storage {
+    markdown: MarkdownStorage;
+  }
+}
 
 // Exit heading on Enter when the current heading is empty (standard editor behavior)
 const HeadingExitExtension = Extension.create({
@@ -26,10 +35,69 @@ const HeadingExitExtension = Extension.create({
   },
 });
 
+// Submit extension: ⌘Enter to submit and blur
+const createSubmitExtension = (onSubmit: () => void) =>
+  Extension.create({
+    name: 'submit',
+    addKeyboardShortcuts() {
+      return {
+        'Mod-Enter': ({ editor }) => {
+          onSubmit();
+          editor.commands.blur();
+          return true;
+        },
+      };
+    },
+  });
+
+// Link extension with markdown serialization support - singleton instance
+// openOnClick is disabled; we handle link clicks manually in readOnly mode
+const MarkdownLinkExtension = Link.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize: defaultMarkdownSerializer.marks.link,
+        parse: {
+          // handled by markdown-it
+        },
+      },
+    };
+  },
+}).configure({
+  openOnClick: false,
+  HTMLAttributes: {
+    class: 'text-primary underline underline-offset-2 cursor-pointer',
+  },
+});
+
+// Image extension with markdown support for tiptap-markdown
+const MarkdownImageExtension = Image.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: PmNode) {
+          state.write(`![${node.attrs.alt || ''}](${node.attrs.src})`);
+        },
+        parse: {
+          // This tells tiptap-markdown to use this extension for images
+        },
+      },
+    };
+  },
+}).configure({
+  inline: true, // Allow images inline with text
+  allowBase64: true, // Important: allow base64 data URLs
+  HTMLAttributes: {
+    class: 'rounded-md max-w-full h-auto',
+  },
+});
+
 interface RichTextEditorProps {
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;
+  /** Called when user submits with ⌘Enter or blur. Editor will lose focus after submit. */
+  onSubmit?: () => void;
   placeholder?: string;
   readOnly?: boolean;
   className?: string;
@@ -39,6 +107,7 @@ export function RichTextEditor({
   value,
   onChange,
   onBlur,
+  onSubmit,
   placeholder = 'Type / for commands...',
   readOnly = false,
   className,
@@ -47,6 +116,8 @@ export function RichTextEditor({
   onChangeRef.current = onChange;
   const onBlurRef = useRef(onBlur);
   onBlurRef.current = onBlur;
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
 
   const [slashMenuOpen, setSlashMenuOpen] = useState(false);
   const [slashMenuPos, setSlashMenuPos] = useState<{ top: number; left: number } | null>(null);
@@ -56,6 +127,8 @@ export function RichTextEditor({
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
+        // Disable link from StarterKit - we use our own MarkdownLinkExtension
+        link: false,
         codeBlock: {
           HTMLAttributes: {
             class: 'rounded-md bg-muted p-3 font-mono text-sm',
@@ -74,20 +147,11 @@ export function RichTextEditor({
         placeholder,
         emptyNodeClass: 'before:content-[attr(data-placeholder)] before:text-muted-foreground/50 before:float-left before:h-0 before:pointer-events-none',
       }),
-      Link.configure({
-        openOnClick: false,
-        HTMLAttributes: {
-          class: 'text-primary underline underline-offset-2 cursor-pointer',
-        },
-      }),
-      Image.configure({
-        inline: false,
-        HTMLAttributes: {
-          class: 'rounded-md max-w-full h-auto',
-        },
-      }),
+      MarkdownLinkExtension,
+      MarkdownImageExtension,
       Markdown,
       HeadingExitExtension,
+      createSubmitExtension(() => onSubmitRef.current?.()),
       SlashMenuExtension.configure({
         onOpen: ({ query, clientRect }) => {
           setSlashQuery(query);
@@ -111,26 +175,17 @@ export function RichTextEditor({
         },
       }),
     ],
-    content: '',
+    content: value || '',
     editable: !readOnly,
-    onCreate: ({ editor: ed }) => {
-      if (value) {
-        // Use the markdown manager's parse method for proper markdown rendering
-        const mdManager = ed.storage.markdown?.manager;
-        if (mdManager) {
-          const parsed = mdManager.parse(value);
-          ed.commands.setContent(parsed);
-        } else {
-          ed.commands.setContent(value);
-        }
-      }
-    },
+    immediatelyRender: false,
     onUpdate: ({ editor: ed }) => {
-      const md = ed.getMarkdown();
+      // tiptap-markdown: use storage.markdown.getMarkdown()
+      const md = ed.storage.markdown.getMarkdown();
       onChangeRef.current(md);
     },
     onBlur: () => {
       onBlurRef.current?.();
+      onSubmitRef.current?.();
     },
     editorProps: {
       attributes: {
@@ -158,15 +213,11 @@ export function RichTextEditor({
   // Sync external value changes
   useEffect(() => {
     if (!editor) return;
-    const currentMd = editor.getMarkdown();
+    // tiptap-markdown: getMarkdown() is on storage.markdown
+    const currentMd = editor.storage.markdown?.getMarkdown() || '';
     if (currentMd !== value && !editor.isFocused) {
-      const mdManager = editor.storage.markdown?.manager;
-      if (mdManager) {
-        const parsed = mdManager.parse(value || '');
-        editor.commands.setContent(parsed);
-      } else {
-        editor.commands.setContent(value || '');
-      }
+      // tiptap-markdown: setContent automatically parses markdown
+      editor.commands.setContent(value || '');
     }
   }, [editor, value]);
 
@@ -246,6 +297,23 @@ export function RichTextEditor({
     [editor, slashQuery],
   );
 
+  // Handle link clicks in readOnly mode
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!readOnly) return;
+      const target = e.target as HTMLElement;
+      const link = target.closest('a');
+      if (link) {
+        e.preventDefault();
+        const href = link.getAttribute('href');
+        if (href) {
+          window.open(href, '_blank', 'noopener,noreferrer');
+        }
+      }
+    },
+    [readOnly],
+  );
+
   return (
     <div
       ref={editorContainerRef}
@@ -255,6 +323,7 @@ export function RichTextEditor({
         !readOnly && 'focus-within:ring-1 focus-within:ring-ring',
         className,
       )}
+      onClick={handleClick}
     >
       <EditorContent
         editor={editor}

--- a/src/components/common/RichTextEditor.tsx
+++ b/src/components/common/RichTextEditor.tsx
@@ -8,6 +8,7 @@ import Image from '@tiptap/extension-image';
 import { Markdown, MarkdownStorage } from 'tiptap-markdown';
 import { defaultMarkdownSerializer, MarkdownSerializerState } from 'prosemirror-markdown';
 import { Node as PmNode } from 'prosemirror-model';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { cn } from '@/lib/utils';
 import { SlashMenu, SlashMenuExtension } from './SlashMenu';
 
@@ -35,14 +36,14 @@ const HeadingExitExtension = Extension.create({
   },
 });
 
-// Submit extension: ⌘Enter to submit and blur
-const createSubmitExtension = (onSubmit: () => void) =>
+// Submit extension: ⌘Enter to blur (which triggers onBlur -> onSubmit)
+// We only blur here; onSubmit is called in onBlur to avoid double submission
+const createSubmitExtension = () =>
   Extension.create({
     name: 'submit',
     addKeyboardShortcuts() {
       return {
         'Mod-Enter': ({ editor }) => {
-          onSubmit();
           editor.commands.blur();
           return true;
         },
@@ -151,7 +152,7 @@ export function RichTextEditor({
       MarkdownImageExtension,
       Markdown,
       HeadingExitExtension,
-      createSubmitExtension(() => onSubmitRef.current?.()),
+      createSubmitExtension(),
       SlashMenuExtension.configure({
         onOpen: ({ query, clientRect }) => {
           setSlashQuery(query);
@@ -297,7 +298,7 @@ export function RichTextEditor({
     [editor, slashQuery],
   );
 
-  // Handle link clicks in readOnly mode
+  // Handle link clicks in readOnly mode using Tauri opener plugin
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!readOnly) return;
@@ -306,8 +307,11 @@ export function RichTextEditor({
       if (link) {
         e.preventDefault();
         const href = link.getAttribute('href');
-        if (href) {
-          window.open(href, '_blank', 'noopener,noreferrer');
+        if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+          openUrl(href).catch(() => {
+            // Fallback for dev mode or if plugin fails
+            window.open(href, '_blank', 'noopener,noreferrer');
+          });
         }
       }
     },

--- a/src/components/task/TaskDetailPanel.tsx
+++ b/src/components/task/TaskDetailPanel.tsx
@@ -86,7 +86,8 @@ export function TaskDetailPanel() {
 
   const handleDescriptionBlur = () => {
     if (task && descriptionValue !== (task.description ?? '')) {
-      updateTask(task.id, { description: descriptionValue || undefined });
+      // Send empty string explicitly to clear description (undefined would be ignored by backend)
+      updateTask(task.id, { description: descriptionValue });
       setTask({ ...task, description: descriptionValue || null });
       showSaved();
     }

--- a/src/components/task/TaskDetailPanel.tsx
+++ b/src/components/task/TaskDetailPanel.tsx
@@ -87,8 +87,9 @@ export function TaskDetailPanel() {
   const handleDescriptionBlur = () => {
     if (task && descriptionValue !== (task.description ?? '')) {
       // Send empty string explicitly to clear description (undefined would be ignored by backend)
+      // Backend stores empty string; we keep local state consistent
       updateTask(task.id, { description: descriptionValue });
-      setTask({ ...task, description: descriptionValue || null });
+      setTask({ ...task, description: descriptionValue || '' });
       showSaved();
     }
     setEditingDescription(false);

--- a/src/components/task/TaskDetailPanel.tsx
+++ b/src/components/task/TaskDetailPanel.tsx
@@ -28,6 +28,7 @@ import { useUIStore } from '@/stores/ui-store';
 import { useTaskStore } from '@/stores/task-store';
 import { useTagStore } from '@/stores/tag-store';
 import { taskService } from '@/services/task-service';
+import { useResolvedMarkdown } from '@/hooks/useResolvedMarkdown';
 import type { TaskDetail, TaskStatus, TaskPriority, TaskDifficulty, DescriptionFormat } from '@/types/task';
 import { VisuallyHidden } from 'radix-ui';
 
@@ -47,6 +48,9 @@ export function TaskDetailPanel() {
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionValue, setDescriptionValue] = useState('');
   const [showFormatChooser, setShowFormatChooser] = useState(false);
+
+  // Resolve image references in markdown (e.g., ![](花束.jpg) -> data URL)
+  const resolvedDescription = useResolvedMarkdown(task?.id ?? null, task?.description ?? null);
 
   // Fetch task detail when taskId changes
   useEffect(() => {
@@ -85,6 +89,15 @@ export function TaskDetailPanel() {
       updateTask(task.id, { description: descriptionValue || undefined });
       setTask({ ...task, description: descriptionValue || null });
       showSaved();
+    }
+    setEditingDescription(false);
+  };
+
+  const handleDescriptionKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // ⌘ Enter to submit
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      e.currentTarget.blur();
     }
   };
 
@@ -157,7 +170,7 @@ export function TaskDetailPanel() {
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) closePanel(); }}>
       <DialogContent
         showCloseButton={false}
-        className="max-w-4xl h-[80vh] min-w-[640px] min-h-[480px] flex flex-col p-0 gap-0"
+        className="max-w-4xl h-[80vh] max-h-[80vh] min-w-[640px] min-h-[480px] flex flex-col p-0 gap-0 overflow-hidden"
         onKeyDown={(e) => {
           if (e.metaKey || e.ctrlKey) return;
           const target = e.target as HTMLElement;
@@ -229,7 +242,7 @@ export function TaskDetailPanel() {
             </div>
 
             {/* Main scrollable content */}
-            <ScrollArea className="flex-1">
+            <ScrollArea className="flex-1 min-h-0">
               <div className="space-y-4 p-6">
                 {/* Description */}
                 <div className="space-y-1.5">
@@ -275,6 +288,7 @@ export function TaskDetailPanel() {
                         value={descriptionValue}
                         onChange={(e) => setDescriptionValue(e.target.value)}
                         onBlur={handleDescriptionBlur}
+                        onKeyDown={handleDescriptionKeyDown}
                         autoFocus
                         placeholder="Write markdown here..."
                         className="w-full min-h-[160px] rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono resize-y focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
@@ -283,24 +297,26 @@ export function TaskDetailPanel() {
                       <RichTextEditor
                         value={descriptionValue}
                         onChange={setDescriptionValue}
-                        onBlur={handleDescriptionBlur}
+                        onSubmit={handleDescriptionBlur}
                         placeholder="Add a description..."
                         className="min-h-[160px]"
                       />
                     )
                   ) : (
                     <div
-                      className="cursor-pointer rounded px-1 -mx-1 py-1 text-sm hover:bg-muted/50 min-h-[80px]"
-                      onClick={handleDescriptionClick}
+                      className="rounded px-1 -mx-1 py-1 text-sm min-h-[80px]"
+                      onDoubleClick={handleDescriptionClick}
                     >
                       {task.description ? (
                         <RichTextEditor
-                          value={task.description}
+                          value={resolvedDescription}
                           onChange={() => {}}
                           readOnly
                         />
                       ) : (
-                        <span className="text-muted-foreground">Add a description...</span>
+                        <span className="text-muted-foreground cursor-pointer" onClick={handleDescriptionClick}>
+                          Add a description...
+                        </span>
                       )}
                     </div>
                   )}

--- a/src/components/task/TaskDetailPanel.tsx
+++ b/src/components/task/TaskDetailPanel.tsx
@@ -49,7 +49,7 @@ export function TaskDetailPanel() {
   const [descriptionValue, setDescriptionValue] = useState('');
   const [showFormatChooser, setShowFormatChooser] = useState(false);
 
-  // Resolve image references in markdown (e.g., ![](花束.jpg) -> data URL)
+  // Resolve image references in markdown (e.g., ![](花束.jpg) -> clotho://image/{id})
   const resolvedDescription = useResolvedMarkdown(task?.id ?? null, task?.description ?? null);
 
   // Fetch task detail when taskId changes

--- a/src/components/task/TaskImageSection.tsx
+++ b/src/components/task/TaskImageSection.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { ImagePlus, X, Loader2, Copy } from 'lucide-react';
+import { ImagePlus, X, Loader2, Copy, ImageIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
 import { imageService } from '@/services/image-service';
 import type { TaskImage } from '@/types/task';
 
@@ -13,7 +12,6 @@ export function TaskImageSection({ taskId }: TaskImageSectionProps) {
   const [images, setImages] = useState<TaskImage[]>([]);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [imageUrls, setImageUrls] = useState<Map<string, string>>(new Map());
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const fetchImages = useCallback(async () => {
@@ -31,32 +29,6 @@ export function TaskImageSection({ taskId }: TaskImageSectionProps) {
   useEffect(() => {
     fetchImages();
   }, [fetchImages]);
-
-  // Load image data for previews
-  useEffect(() => {
-    const urls = new Map<string, string>();
-    let cancelled = false;
-
-    async function loadAll() {
-      for (const img of images) {
-        if (cancelled) break;
-        try {
-          const base64 = await imageService.get(img.id);
-          urls.set(img.id, `data:${img.mime_type};base64,${base64}`);
-        } catch {
-          // skip
-        }
-      }
-      if (!cancelled) {
-        setImageUrls(new Map(urls));
-      }
-    }
-
-    loadAll();
-    return () => {
-      cancelled = true;
-    };
-  }, [images]);
 
   const handleUpload = useCallback(async (files: FileList) => {
     setUploading(true);
@@ -84,14 +56,16 @@ export function TaskImageSection({ taskId }: TaskImageSectionProps) {
   }, []);
 
   const handleCopyRef = useCallback((image: TaskImage) => {
-    const ref = `![${image.filename}](clotho://image/${image.id})`;
+    const ref = `![${image.filename}](${image.filename})`;
     navigator.clipboard.writeText(ref);
   }, []);
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <label className="text-xs font-medium text-muted-foreground">Images</label>
+        <label className="text-xs font-medium text-muted-foreground">
+          Images {images.length > 0 && `(${images.length})`}
+        </label>
         <Button
           variant="ghost"
           size="sm"
@@ -122,65 +96,47 @@ export function TaskImageSection({ taskId }: TaskImageSectionProps) {
       </div>
 
       {loading && images.length === 0 ? (
-        <div className="flex items-center justify-center py-4">
+        <div className="flex items-center justify-center py-2">
           <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
         </div>
       ) : images.length === 0 ? (
         <div
-          className="flex items-center justify-center rounded-md border border-dashed py-4 text-sm text-muted-foreground cursor-pointer hover:bg-muted/30 transition-colors"
+          className="flex items-center justify-center rounded-md border border-dashed py-3 text-sm text-muted-foreground cursor-pointer hover:bg-muted/30 transition-colors"
           onClick={() => fileInputRef.current?.click()}
         >
           Click to upload images
         </div>
       ) : (
-        <div className="grid grid-cols-3 gap-2">
-          {images.map((img) => {
-            const url = imageUrls.get(img.id);
-            return (
-              <div
-                key={img.id}
-                className="group relative aspect-square rounded-md border overflow-hidden bg-muted/30"
-              >
-                {url ? (
-                  <img
-                    src={url}
-                    alt={img.filename}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <div className="flex h-full items-center justify-center">
-                    <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                  </div>
-                )}
-                <div className={cn(
-                  'absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity',
-                  'flex items-center justify-center gap-1',
-                )}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 text-white hover:bg-white/20"
-                    title="Copy reference"
-                    onClick={(e) => { e.stopPropagation(); handleCopyRef(img); }}
-                  >
-                    <Copy className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 text-white hover:bg-white/20"
-                    title="Delete"
-                    onClick={(e) => { e.stopPropagation(); handleDelete(img.id); }}
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-                <div className="absolute bottom-0 left-0 right-0 bg-black/60 px-1.5 py-0.5 text-[10px] text-white truncate opacity-0 group-hover:opacity-100 transition-opacity">
-                  {img.filename}
-                </div>
+        <div className="space-y-1">
+          {images.map((img) => (
+            <div
+              key={img.id}
+              className="group flex items-center gap-2 rounded-md px-2 py-1 hover:bg-muted/50 transition-colors"
+            >
+              <ImageIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="flex-1 text-sm truncate">{img.filename}</span>
+              <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  title="Copy markdown reference"
+                  onClick={() => handleCopyRef(img)}
+                >
+                  <Copy className="h-3 w-3" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-destructive hover:text-destructive"
+                  title="Delete"
+                  onClick={() => handleDelete(img.id)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
               </div>
-            );
-          })}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/task/TaskImageSection.tsx
+++ b/src/components/task/TaskImageSection.tsx
@@ -56,7 +56,7 @@ export function TaskImageSection({ taskId }: TaskImageSectionProps) {
   }, []);
 
   const handleCopyRef = useCallback((image: TaskImage) => {
-    const ref = `![${image.filename}](${image.filename})`;
+    const ref = `![${image.filename}](clotho://image/${image.id})`;
     navigator.clipboard.writeText(ref);
   }, []);
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -58,6 +58,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        aria-describedby={undefined}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -49,16 +49,19 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  hideDescription = false,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  /** Set to true to suppress aria-describedby warning when no DialogDescription is used */
+  hideDescription?: boolean
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
-        aria-describedby={undefined}
+        aria-describedby={hideDescription ? undefined : props["aria-describedby"]}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -13,12 +13,13 @@ function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative overflow-hidden", className)}
       {...props}
     >
+      {/* [&>div]:!block overrides Radix's internal display:table which breaks flex layouts */}
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="size-full rounded-[inherit] [&>div]:!block"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -19,7 +19,7 @@ function ScrollArea({
       {/* [&>div]:!block overrides Radix's internal display:table which breaks flex layouts */}
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] [&>div]:!block"
+        className="size-full rounded-[inherit] [&>div]:!block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/src/hooks/useResolvedMarkdown.ts
+++ b/src/hooks/useResolvedMarkdown.ts
@@ -1,0 +1,95 @@
+import { useState, useEffect } from 'react';
+import { imageService } from '@/services/image-service';
+
+/**
+ * Hook to resolve image references in markdown content.
+ * Converts `![alt](filename.jpg)` to `![alt](data:image/...;base64,...)` for images
+ * that exist in the task's image attachments.
+ */
+export function useResolvedMarkdown(taskId: string | null, markdown: string | null): string {
+  const [resolved, setResolved] = useState(markdown ?? '');
+
+  useEffect(() => {
+    if (!taskId || !markdown) {
+      setResolved(markdown ?? '');
+      return;
+    }
+
+    let cancelled = false;
+    const tid = taskId; // Capture for closure (narrowed to string)
+    const md = markdown; // Capture for closure
+
+    async function resolve() {
+      // Find all image references: ![alt](src)
+      const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+      const matches = [...md.matchAll(imageRegex)];
+
+      if (matches.length === 0) {
+        setResolved(md);
+        return;
+      }
+
+      // Filter to only local file references (not URLs or data URIs)
+      const localRefs = matches.filter(([, , src]) => {
+        return !src.startsWith('http://') &&
+               !src.startsWith('https://') &&
+               !src.startsWith('data:') &&
+               !src.startsWith('clotho://');
+      });
+
+      if (localRefs.length === 0) {
+        setResolved(md);
+        return;
+      }
+
+      // Load images and build replacement map
+      const replacements = new Map<string, string>();
+
+      // Get all images for this task
+      let images: Awaited<ReturnType<typeof imageService.list>> = [];
+      try {
+        images = await imageService.list(tid);
+      } catch {
+        setResolved(md);
+        return;
+      }
+
+      // Create a filename -> image map
+      const imageByFilename = new Map(images.map(img => [img.filename, img]));
+
+      // Load each referenced image
+      for (const [fullMatch, alt, filename] of localRefs) {
+        if (cancelled) return;
+
+        const image = imageByFilename.get(filename);
+        if (image) {
+          try {
+            const base64 = await imageService.get(image.id);
+            const dataUrl = `data:${image.mime_type};base64,${base64}`;
+            replacements.set(fullMatch, `![${alt || filename}](${dataUrl})`);
+          } catch {
+            // Keep original reference if loading fails
+          }
+        }
+      }
+
+      if (cancelled) return;
+
+      // Apply replacements
+      let result = md;
+      for (const [original, replacement] of replacements) {
+        result = result.replace(original, replacement);
+      }
+
+      setResolved(result);
+    }
+
+    resolve();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [taskId, markdown]);
+
+  return resolved;
+}

--- a/src/hooks/useResolvedMarkdown.ts
+++ b/src/hooks/useResolvedMarkdown.ts
@@ -3,8 +3,11 @@ import { imageService } from '@/services/image-service';
 
 /**
  * Hook to resolve image references in markdown content.
- * Converts `![alt](filename.jpg)` to `![alt](data:image/...;base64,...)` for images
+ * Converts `![alt](filename.jpg)` to `![alt](clotho://image/{id})` for images
  * that exist in the task's image attachments.
+ *
+ * The `clotho://` protocol is handled by Tauri's custom protocol handler,
+ * which serves images directly as binary data with proper caching headers.
  */
 export function useResolvedMarkdown(taskId: string | null, markdown: string | null): string {
   const [resolved, setResolved] = useState(markdown ?? '');
@@ -29,7 +32,7 @@ export function useResolvedMarkdown(taskId: string | null, markdown: string | nu
         return;
       }
 
-      // Filter to only local file references (not URLs or data URIs)
+      // Filter to only local file references (not URLs, data URIs, or clotho:// protocol)
       const localRefs = matches.filter(([, , src]) => {
         return !src.startsWith('http://') &&
                !src.startsWith('https://') &&
@@ -42,7 +45,7 @@ export function useResolvedMarkdown(taskId: string | null, markdown: string | nu
         return;
       }
 
-      // Load images and build replacement map
+      // Load images metadata to build replacement map
       const replacements = new Map<string, string>();
 
       // Get all images for this task
@@ -57,19 +60,15 @@ export function useResolvedMarkdown(taskId: string | null, markdown: string | nu
       // Create a filename -> image map
       const imageByFilename = new Map(images.map(img => [img.filename, img]));
 
-      // Load each referenced image
+      // Build replacements for each filename reference -> clotho:// URL
       for (const [fullMatch, alt, filename] of localRefs) {
         if (cancelled) return;
 
         const image = imageByFilename.get(filename);
         if (image) {
-          try {
-            const base64 = await imageService.get(image.id);
-            const dataUrl = `data:${image.mime_type};base64,${base64}`;
-            replacements.set(fullMatch, `![${alt || filename}](${dataUrl})`);
-          } catch {
-            // Keep original reference if loading fails
-          }
+          // Convert to clotho:// protocol URL
+          const clothoUrl = `clotho://image/${image.id}`;
+          replacements.set(fullMatch, `![${alt || filename}](${clothoUrl})`);
         }
       }
 

--- a/src/hooks/useResolvedMarkdown.ts
+++ b/src/hooks/useResolvedMarkdown.ts
@@ -18,6 +18,12 @@ export function useResolvedMarkdown(taskId: string | null, markdown: string | nu
       return;
     }
 
+    // Quick check: if no image syntax present, skip the backend call
+    if (!markdown.includes('![')) {
+      setResolved(markdown);
+      return;
+    }
+
     let cancelled = false;
     const tid = taskId;
     const md = markdown;
@@ -34,13 +40,20 @@ export function useResolvedMarkdown(taskId: string | null, markdown: string | nu
 
       if (cancelled) return;
 
+      // If no images attached, nothing to resolve
+      if (images.length === 0) {
+        setResolved(md);
+        return;
+      }
+
       // Create a filename -> image map
       const imageByFilename = new Map(images.map(img => [img.filename, img]));
 
       // Replace all local image references with clotho:// URLs
-      // Use replaceAll with callback to handle multiple occurrences
-      const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
-      const result = md.replace(imageRegex, (match, alt, src) => {
+      // Using String.replace with a global regex and callback to handle all occurrences
+      // Supports: ![alt](src) and ![alt](src "title")
+      const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+      const result = md.replace(imageRegex, (match, _alt, src) => {
         // Skip URLs, data URIs, and already-converted clotho:// URLs
         if (src.startsWith('http://') ||
             src.startsWith('https://') ||
@@ -51,8 +64,8 @@ export function useResolvedMarkdown(taskId: string | null, markdown: string | nu
 
         const image = imageByFilename.get(src);
         if (image) {
-          // Preserve original alt text exactly
-          return `![${alt}](clotho://image/${image.id})`;
+          // Preserve original alt text exactly, replace only the src part
+          return match.replace(src, `clotho://image/${image.id}`);
         }
 
         return match;

--- a/src/hooks/useResolvedMarkdown.ts
+++ b/src/hooks/useResolvedMarkdown.ts
@@ -19,68 +19,46 @@ export function useResolvedMarkdown(taskId: string | null, markdown: string | nu
     }
 
     let cancelled = false;
-    const tid = taskId; // Capture for closure (narrowed to string)
-    const md = markdown; // Capture for closure
+    const tid = taskId;
+    const md = markdown;
 
     async function resolve() {
-      // Find all image references: ![alt](src)
-      const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
-      const matches = [...md.matchAll(imageRegex)];
-
-      if (matches.length === 0) {
-        setResolved(md);
-        return;
-      }
-
-      // Filter to only local file references (not URLs, data URIs, or clotho:// protocol)
-      const localRefs = matches.filter(([, , src]) => {
-        return !src.startsWith('http://') &&
-               !src.startsWith('https://') &&
-               !src.startsWith('data:') &&
-               !src.startsWith('clotho://');
-      });
-
-      if (localRefs.length === 0) {
-        setResolved(md);
-        return;
-      }
-
-      // Load images metadata to build replacement map
-      const replacements = new Map<string, string>();
-
       // Get all images for this task
       let images: Awaited<ReturnType<typeof imageService.list>> = [];
       try {
         images = await imageService.list(tid);
       } catch {
-        setResolved(md);
+        if (!cancelled) setResolved(md);
         return;
-      }
-
-      // Create a filename -> image map
-      const imageByFilename = new Map(images.map(img => [img.filename, img]));
-
-      // Build replacements for each filename reference -> clotho:// URL
-      for (const [fullMatch, alt, filename] of localRefs) {
-        if (cancelled) return;
-
-        const image = imageByFilename.get(filename);
-        if (image) {
-          // Convert to clotho:// protocol URL
-          const clothoUrl = `clotho://image/${image.id}`;
-          replacements.set(fullMatch, `![${alt || filename}](${clothoUrl})`);
-        }
       }
 
       if (cancelled) return;
 
-      // Apply replacements
-      let result = md;
-      for (const [original, replacement] of replacements) {
-        result = result.replace(original, replacement);
-      }
+      // Create a filename -> image map
+      const imageByFilename = new Map(images.map(img => [img.filename, img]));
 
-      setResolved(result);
+      // Replace all local image references with clotho:// URLs
+      // Use replaceAll with callback to handle multiple occurrences
+      const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+      const result = md.replace(imageRegex, (match, alt, src) => {
+        // Skip URLs, data URIs, and already-converted clotho:// URLs
+        if (src.startsWith('http://') ||
+            src.startsWith('https://') ||
+            src.startsWith('data:') ||
+            src.startsWith('clotho://')) {
+          return match;
+        }
+
+        const image = imageByFilename.get(src);
+        if (image) {
+          // Preserve original alt text exactly
+          return `![${alt}](clotho://image/${image.id})`;
+        }
+
+        return match;
+      });
+
+      if (!cancelled) setResolved(result);
     }
 
     resolve();

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -8,12 +8,6 @@ export const imageService = {
   upload: (taskId: string, filename: string, data: number[], mimeType: string) =>
     invoke<TaskImage>('upload_task_image', { taskId, filename, data, mimeType }),
 
-  get: (id: string) =>
-    invoke<string>('get_task_image', { id }),
-
-  getByFilename: (taskId: string, filename: string) =>
-    invoke<string>('get_task_image_by_filename', { taskId, filename }),
-
   delete: (id: string) =>
     invoke('delete_task_image', { id }),
 };

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -11,6 +11,9 @@ export const imageService = {
   get: (id: string) =>
     invoke<string>('get_task_image', { id }),
 
+  getByFilename: (taskId: string, filename: string) =>
+    invoke<string>('get_task_image_by_filename', { taskId, filename }),
+
   delete: (id: string) =>
     invoke('delete_task_image', { id }),
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary
- Improve markdown rendering with custom components
- Use Tauri custom protocol (`clotho://image/{id}`) for images instead of base64
- Add browser caching support for images

## Changes
- Register `clotho://` protocol handler serving binary image data
- Update image reference format to use protocol URLs
- Simplify `useResolvedMarkdown` hook (no more base64 conversion)

## Benefits
- No base64 encoding overhead (33% size reduction)
- Browser caching with immutable Cache-Control header
- Lower memory usage
- Backward compatible with old filename references