### PR TITLE
ci: add workflow to block AI agent commits

### DIFF
--- a/.github/workflows/block-ai-authors.yml
+++ b/.github/workflows/block-ai-authors.yml
@@ -1,0 +1,87 @@
+name: Block AI Authors
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-authors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block AI agent commits
+        run: |
+          # List of blocked AI patterns (case-insensitive)
+          BLOCKED_PATTERNS=(
+            "claude"
+            "anthropic"
+            "openai"
+            "chatgpt"
+          )
+
+          # Build grep pattern
+          PATTERN=$(IFS='|'; echo "${BLOCKED_PATTERNS[*]}")
+
+          # Get commit range
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            # For push, check commits in this push
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.event.after }}"
+            # Handle initial push
+            if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+              echo "Initial push, skipping check"
+              exit 0
+            fi
+          fi
+
+          echo "Checking commits from $BASE to $HEAD"
+
+          FAILED=0
+
+          # Check each commit
+          for COMMIT in $(git rev-list $BASE..$HEAD); do
+            echo "Checking commit: $COMMIT"
+
+            # Check author name and email
+            AUTHOR_NAME=$(git log -1 --format='%an' $COMMIT)
+            AUTHOR_EMAIL=$(git log -1 --format='%ae' $COMMIT)
+            COMMITTER_NAME=$(git log -1 --format='%cn' $COMMIT)
+            COMMITTER_EMAIL=$(git log -1 --format='%ce' $COMMIT)
+
+            if echo "$AUTHOR_NAME $AUTHOR_EMAIL" | grep -iEq "$PATTERN"; then
+              echo "::error::Commit $COMMIT has blocked AI author: $AUTHOR_NAME <$AUTHOR_EMAIL>"
+              FAILED=1
+            fi
+
+            if echo "$COMMITTER_NAME $COMMITTER_EMAIL" | grep -iEq "$PATTERN"; then
+              echo "::error::Commit $COMMIT has blocked AI committer: $COMMITTER_NAME <$COMMITTER_EMAIL>"
+              FAILED=1
+            fi
+
+            # Check commit message for Co-authored-by
+            COMMIT_MSG=$(git log -1 --format='%B' $COMMIT)
+            if echo "$COMMIT_MSG" | grep -iE "co-authored-by:.*($PATTERN)" > /dev/null; then
+              COAUTHOR=$(echo "$COMMIT_MSG" | grep -iE "co-authored-by:.*($PATTERN)")
+              echo "::error::Commit $COMMIT has blocked AI co-author: $COAUTHOR"
+              FAILED=1
+            fi
+          done
+
+          if [ $FAILED -eq 1 ]; then
+            echo ""
+            echo "=========================================="
+            echo "AI agent commits are not allowed."
+            echo "Please rewrite history to remove AI authors."
+            echo "=========================================="
+            exit 1
+          fi
+
+          echo "All commits passed author check."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           cache: pnpm
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           - platform: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             name: Linux ARM64
+            bundles: deb,rpm
 
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
@@ -92,7 +93,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }} ${{ matrix.bundles && format('--bundles {0}', matrix.bundles) || '' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -102,6 +103,7 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
             src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
             src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
             src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,108 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+            name: macOS ARM64
+
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            name: Linux AMD64
+
+          - platform: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
+            name: Linux ARM64
+
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+            name: Windows AMD64
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Linux dependencies (AMD64)
+        if: matrix.platform == 'ubuntu-22.04' && matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Install Linux dependencies (ARM64 cross-compile)
+        if: matrix.platform == 'ubuntu-22.04' && matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu \
+            libwebkit2gtk-4.1-dev:arm64 \
+            libappindicator3-dev:arm64 \
+            librsvg2-dev:arm64 \
+            patchelf
+          echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --target ${{ matrix.target }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: clotho-${{ matrix.target }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+            src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Clotho
+<p align="center">
+  <img src="src-tauri/icons/128x128.png" alt="Clotho Logo" width="128" height="128">
+</p>
 
-A task management desktop application built with Tauri 2, React 19, and TypeScript.
+<h1 align="center">Clotho</h1>
+
+<p align="center">A task management desktop application built with Tauri 2, React 19, and TypeScript.</p>
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to block commits from AI agents (Claude, Anthropic, OpenAI, ChatGPT)
- Checks author, committer, and Co-authored-by in commit messages
- Copilot and other bots are allowed

## Test plan
- [ ] Verify workflow runs on PR
- [ ] Test that blocked patterns are correctly detected