### PR TITLE
feat: add task tag editing and quick create in task forms

### DIFF
--- a/src/components/task/TaskCreateDialog.tsx
+++ b/src/components/task/TaskCreateDialog.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Type, Code, X } from 'lucide-react';
+import { toast } from 'sonner';
 import {
   Dialog,
   DialogContent,
@@ -11,6 +12,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { TaskForm } from '@/components/task/TaskForm';
 import type { TaskFormValue } from '@/components/task/TaskForm';
+import { useTagStore } from '@/stores/tag-store';
 import type { CreateTaskInput, TaskStatus, TaskPriority, DescriptionFormat } from '@/types/task';
 import type { Tag } from '@/types/tag';
 import { VisuallyHidden } from 'radix-ui';
@@ -34,6 +36,9 @@ export function TaskCreateDialog({
   defaultStatus = 'todo',
   defaultPriority = 'low',
 }: TaskCreateDialogProps) {
+  const createTag = useTagStore((s) => s.createTag);
+  const fetchTags = useTagStore((s) => s.fetchTags);
+
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [descriptionFormat, setDescriptionFormat] = useState<DescriptionFormat | null>(null);
@@ -48,6 +53,11 @@ export function TaskCreateDialog({
     estimatedHours: null,
     actualHours: null,
   });
+
+  useEffect(() => {
+    if (!open || allTags.length > 0) return;
+    void fetchTags();
+  }, [open, allTags.length, fetchTags]);
 
   const resetForm = () => {
     setTitle('');
@@ -106,6 +116,24 @@ export function TaskCreateDialog({
     setShowFormatChooser(false);
   };
 
+  const handleCreateTag = async (name: string, color: string): Promise<Tag> => {
+    try {
+      return await createTag({ name, color });
+    } catch (error) {
+      const message = String(error).toLowerCase();
+      if (message.includes('already exists') || message.includes('conflict')) {
+        await fetchTags();
+        const existing = useTagStore
+          .getState()
+          .tags
+          .find((tag) => tag.name.toLowerCase() === name.toLowerCase());
+        if (existing) return existing;
+      }
+      toast.error('Failed to create tag');
+      throw error;
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
@@ -153,6 +181,7 @@ export function TaskCreateDialog({
               value={formValue}
               onChange={(update) => setFormValue((prev) => ({ ...prev, ...update }))}
               allTags={allTags}
+              onCreateTag={handleCreateTag}
             />
           </div>
 

--- a/src/components/task/TaskDetailPanel.tsx
+++ b/src/components/task/TaskDetailPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { Type, Code, Check, X, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -30,6 +31,7 @@ import { useTagStore } from '@/stores/tag-store';
 import { taskService } from '@/services/task-service';
 import { useResolvedMarkdown } from '@/hooks/useResolvedMarkdown';
 import type { TaskDetail, TaskStatus, TaskPriority, TaskDifficulty, DescriptionFormat } from '@/types/task';
+import type { Tag } from '@/types/tag';
 import { VisuallyHidden } from 'radix-ui';
 
 export function TaskDetailPanel() {
@@ -39,6 +41,8 @@ export function TaskDetailPanel() {
   const updateTask = useTaskStore((s) => s.updateTask);
   const deleteTask = useTaskStore((s) => s.deleteTask);
   const allTags = useTagStore((s) => s.tags);
+  const fetchTags = useTagStore((s) => s.fetchTags);
+  const createTag = useTagStore((s) => s.createTag);
 
   const [task, setTask] = useState<TaskDetail | null>(null);
   const [loading, setLoading] = useState(false);
@@ -65,6 +69,11 @@ export function TaskDetailPanel() {
       setTask(null);
     }
   }, [taskId]);
+
+  useEffect(() => {
+    if (!open || !taskId || allTags.length > 0) return;
+    void fetchTags();
+  }, [open, taskId, allTags.length, fetchTags]);
 
   useEffect(() => {
     if (task) {
@@ -129,6 +138,24 @@ export function TaskDetailPanel() {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => setSaveIndicator('idle'), 2000);
   }, []);
+
+  const handleCreateTag = useCallback(async (name: string, color: string): Promise<Tag> => {
+    try {
+      return await createTag({ name, color });
+    } catch (error) {
+      const message = String(error).toLowerCase();
+      if (message.includes('already exists') || message.includes('conflict')) {
+        await fetchTags();
+        const existing = useTagStore
+          .getState()
+          .tags
+          .find((tag) => tag.name.toLowerCase() === name.toLowerCase());
+        if (existing) return existing;
+      }
+      toast.error('Failed to create tag');
+      throw error;
+    }
+  }, [createTag, fetchTags]);
 
   const handleFormChange = (update: Partial<{ status: TaskStatus; priority: TaskPriority; difficulty: TaskDifficulty | null; startDate: string | null; dueDate: string | null; tagIds: string[]; estimatedHours: number | null; actualHours: number | null }>) => {
     if (!task) return;
@@ -239,6 +266,7 @@ export function TaskDetailPanel() {
                 }}
                 onChange={handleFormChange}
                 allTags={allTags}
+                onCreateTag={handleCreateTag}
                 showActualHours
               />
             </div>

--- a/src/components/task/TaskForm.tsx
+++ b/src/components/task/TaskForm.tsx
@@ -4,6 +4,8 @@ import { format, parseISO } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { PriorityBadge } from '@/components/common/PriorityBadge';
+import { TagChip } from '@/components/common/TagChip';
+import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Calendar } from '@/components/ui/calendar';
@@ -15,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { TASK_STATUSES, TASK_PRIORITIES, TASK_DIFFICULTIES } from '@/lib/constants';
+import { TASK_STATUSES, TASK_PRIORITIES, TASK_DIFFICULTIES, PROJECT_COLORS } from '@/lib/constants';
 import type { TaskStatus, TaskPriority, TaskDifficulty } from '@/types/task';
 import type { Tag } from '@/types/tag';
 
@@ -40,17 +42,54 @@ interface TaskFormProps {
   value: TaskFormValue;
   onChange: (update: Partial<TaskFormValue>) => void;
   allTags: Tag[];
+  onCreateTag?: (name: string, color: string) => Promise<Tag>;
   showActualHours?: boolean;
 }
 
-export function TaskForm({ value, onChange, allTags, showActualHours = false }: TaskFormProps) {
+export function TaskForm({ value, onChange, allTags, onCreateTag, showActualHours = false }: TaskFormProps) {
   const [startDateOpen, setStartDateOpen] = useState(false);
   const [dueDateOpen, setDueDateOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState('');
+  const [newTagName, setNewTagName] = useState('');
+  const [creatingTag, setCreatingTag] = useState(false);
 
   const filteredTags = tagSearch
     ? allTags.filter((t) => t.name.toLowerCase().includes(tagSearch.toLowerCase()))
     : allTags;
+  const selectedTags = allTags.filter((t) => value.tagIds.includes(t.id));
+
+  const addTagId = (tagId: string) => {
+    if (value.tagIds.includes(tagId)) return;
+    onChange({ tagIds: [...value.tagIds, tagId] });
+  };
+
+  const removeTagId = (tagId: string) => {
+    onChange({ tagIds: value.tagIds.filter((id) => id !== tagId) });
+  };
+
+  const handleCreateTag = async () => {
+    if (!onCreateTag || creatingTag) return;
+    const name = newTagName.trim();
+    if (!name) return;
+
+    const existing = allTags.find((tag) => tag.name.toLowerCase() === name.toLowerCase());
+    if (existing) {
+      addTagId(existing.id);
+      setNewTagName('');
+      return;
+    }
+
+    setCreatingTag(true);
+    try {
+      const color = PROJECT_COLORS[allTags.length % PROJECT_COLORS.length];
+      const created = await onCreateTag(name, color);
+      addTagId(created.id);
+      setNewTagName('');
+      setTagSearch('');
+    } finally {
+      setCreatingTag(false);
+    }
+  };
 
   return (
     <div className="space-y-3">
@@ -256,49 +295,83 @@ export function TaskForm({ value, onChange, allTags, showActualHours = false }: 
       </div>
 
       {/* Tags */}
-      {allTags.length > 0 && (
-        <div className="space-y-1.5">
-          <label className="text-xs font-medium text-muted-foreground">Tags</label>
-          <div className="rounded-md border p-3 space-y-2">
-            <Input
-              value={tagSearch}
-              onChange={(e) => setTagSearch(e.target.value)}
-              placeholder="Search tags..."
-              className="h-7 text-sm"
-            />
-            <div className="max-h-32 overflow-y-auto space-y-0.5">
-              {filteredTags.map((tag) => {
-                const checked = value.tagIds.includes(tag.id);
-                return (
-                  <label
-                    key={tag.id}
-                    className="flex items-center gap-2 rounded-sm px-2 py-1 text-sm hover:bg-accent cursor-pointer transition-colors"
-                  >
-                    <Checkbox
-                      checked={checked}
-                      onCheckedChange={(c) => {
-                        onChange({
-                          tagIds: c
-                            ? [...value.tagIds, tag.id]
-                            : value.tagIds.filter((id) => id !== tag.id),
-                        });
-                      }}
-                    />
-                    <span
-                      className="h-2 w-2 rounded-full shrink-0"
-                      style={{ backgroundColor: tag.color }}
-                    />
-                    <span className="truncate">{tag.name}</span>
-                  </label>
-                );
-              })}
-              {filteredTags.length === 0 && (
-                <p className="text-xs text-muted-foreground text-center py-2">No tags found</p>
-              )}
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">Tags</label>
+        <div className="rounded-md border p-3 space-y-2">
+          {selectedTags.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {selectedTags.map((tag) => (
+                <TagChip key={tag.id} tag={tag} onRemove={() => removeTagId(tag.id)} />
+              ))}
             </div>
+          )}
+          <div className="flex gap-2">
+            <Input
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+              placeholder="Create tag..."
+              className="h-7 text-sm"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void handleCreateTag();
+                }
+              }}
+              disabled={!onCreateTag || creatingTag}
+            />
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 shrink-0"
+              onClick={() => {
+                void handleCreateTag();
+              }}
+              disabled={!onCreateTag || creatingTag || !newTagName.trim()}
+            >
+              Add
+            </Button>
+          </div>
+          <Input
+            value={tagSearch}
+            onChange={(e) => setTagSearch(e.target.value)}
+            placeholder="Search tags..."
+            className="h-7 text-sm"
+          />
+          <div className="max-h-32 overflow-y-auto space-y-0.5">
+            {filteredTags.map((tag) => {
+              const checked = value.tagIds.includes(tag.id);
+              return (
+                <label
+                  key={tag.id}
+                  className="flex items-center gap-2 rounded-sm px-2 py-1 text-sm hover:bg-accent cursor-pointer transition-colors"
+                >
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={(checkedValue) => {
+                      if (checkedValue) {
+                        addTagId(tag.id);
+                        return;
+                      }
+                      removeTagId(tag.id);
+                    }}
+                  />
+                  <span
+                    className="h-2 w-2 rounded-full shrink-0"
+                    style={{ backgroundColor: tag.color }}
+                  />
+                  <span className="truncate">{tag.name}</span>
+                </label>
+              );
+            })}
+            {filteredTags.length === 0 && (
+              <p className="text-xs text-muted-foreground text-center py-2">
+                {allTags.length === 0 ? 'No tags yet. Create your first tag above.' : 'No tags found'}
+              </p>
+            )}
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Purpose / 目的
- Add complete task tag editing UX in both Task Detail and Task Create dialog.
- 在 Task Detail 与 Task Create Dialog 中补齐任务标签编辑体验。
- Close the gap where users could not conveniently manage tags from these forms.
- 解决用户在这些表单中无法便捷管理标签的问题。

## Approach / 方案
- Enhance `TaskForm` tag area to always be visible.
- 增强 `TaskForm` 的标签区域为始终可见。
- Add selected-tag chips with remove action.
- 增加已选标签 chip 并支持移除。
- Add quick-create input for tags with automatic color assignment.
- 增加标签快速创建输入，使用自动配色策略。
- Wire tag creation into both Task Detail and Task Create dialog.
- 将标签创建能力接入 Task Detail 和 Task Create Dialog。

## Implementation Details / 实现细节
- `TaskForm`
  - Added `onCreateTag?: (name, color) => Promise<Tag>`.
  - Added selected chip rendering via `TagChip` with inline remove.
  - Added quick-create flow (Enter/Add button) with rules:
    - Trim empty name -> no-op.
    - Case-insensitive duplicate -> select existing tag.
    - New tag color -> `PROJECT_COLORS[allTags.length % PROJECT_COLORS.length]`.
- `TaskDetailPanel`
  - Fetch tags when panel opens and tag list is empty.
  - Pass `onCreateTag` to `TaskForm`.
  - Handle create errors; on conflict, refresh tags and resolve existing tag.
- `TaskCreateDialog`
  - Fetch tags on open when list is empty.
  - Pass `onCreateTag` to `TaskForm`.
  - Handle create errors; on conflict, refresh tags and resolve existing tag.

## Testing / 测试
- `pnpm build` ✅
- Manual verification points:
  - Task Create dialog can create/select/remove tags.
  - Task Detail can create/select/remove tags.
  - Duplicate tag names are resolved to existing tags.

## Risk & Rollback / 风险与回滚
- Risk: minimal UI behavior change scoped to task form tag interactions.
- 风险：仅影响任务表单的标签交互，范围较小。
- Rollback: revert this PR commit.
- 回滚：回退本 PR 提交即可。

Closes #4
