### PR TITLE
feat: reduce opacity for done/cancelled gantt items

### DIFF
--- a/src/components/views/gantt/GanttTaskBar.tsx
+++ b/src/components/views/gantt/GanttTaskBar.tsx
@@ -81,11 +81,14 @@ export function GanttTaskBar({
   const barY = y + BAR_TOP_OFFSET;
   const isDone = task.status === 'done';
   const isCancelled = task.status === 'cancelled';
+  const isCompleted = isDone || isCancelled;
   const isTodo = task.status === 'todo';
   const isInProgress = task.status === 'in_progress';
   const isActiveStatus = isTodo || isInProgress;
   const barColor = softenHexColor(color);
   const gradientId = `gradient-${clipId}`;
+  const completedOpacity = isCompleted ? 0.62 : 1;
+  const completedTextOpacity = isCompleted ? 0.88 : 1;
 
   // Show name in bar if wide enough
   const showNameInBar = width >= 50;
@@ -290,7 +293,7 @@ export function GanttTaskBar({
         rx={4}
         ry={4}
         fill={dragState?.overUnscheduled ? '#ef4444' : isActiveStatus ? `url(#${gradientId})` : barColor}
-        opacity={dragState?.overUnscheduled ? 0.3 : 1}
+        opacity={dragState?.overUnscheduled ? 0.3 : completedOpacity}
         className="hover:brightness-105 transition-all"
       />
 
@@ -329,13 +332,14 @@ export function GanttTaskBar({
       {showNameInBar && (
         <>
           {/* Status icon for done/cancelled tasks */}
-          {(isDone || isCancelled) && (
+          {isCompleted && (
             <foreignObject
               x={displayX + 4}
               y={displayY + BAR_HEIGHT / 2 - 5}
               width={10}
               height={10}
               className="pointer-events-none"
+              opacity={completedTextOpacity}
             >
               <div className="h-2.5 w-2.5 text-white">
                 {isDone ? <CheckCircle2 className="h-2.5 w-2.5" /> : <XCircle className="h-2.5 w-2.5" />}
@@ -350,6 +354,7 @@ export function GanttTaskBar({
             className="pointer-events-none select-none"
             clipPath={`url(#${clipId})`}
             textDecoration={isDone || isCancelled ? 'line-through' : undefined}
+            opacity={completedTextOpacity}
           >
             {displayTitle}
           </text>
@@ -360,13 +365,14 @@ export function GanttTaskBar({
       {showNameOnRight && (
         <text
           x={displayX + displayWidth + 6}
-          y={displayY + BAR_HEIGHT / 2 + 4}
-          fontSize={11}
-          fill="currentColor"
-          className="pointer-events-none select-none opacity-70"
-        >
-          {task.title}
-        </text>
+        y={displayY + BAR_HEIGHT / 2 + 4}
+        fontSize={11}
+        fill="currentColor"
+        className="pointer-events-none select-none"
+        opacity={isCompleted ? 0.5 : 0.7}
+      >
+        {task.title}
+      </text>
       )}
 
       {/* Left resize handle */}


### PR DESCRIPTION
## Purpose / 目的
- Make completed (`done`) and cancelled gantt items visually lighter.
- 降低已完成（`done`）与已取消（`cancelled`）Gantt 条目的视觉权重。

## Approach / 方案
- Adjust opacity in gantt task bar rendering for completed/cancelled statuses.
- 在 Gantt 任务条渲染中对 completed/cancelled 状态施加更高透明度。
- Keep active statuses unchanged.
- 活跃状态保持不变。

## Implementation Details / 实现细节
- Updated `GanttTaskBar`:
  - Added `isCompleted` derived flag.
  - Applied lower bar opacity for completed/cancelled bars.
  - Applied slightly reduced text/icon opacity for completed/cancelled labels.
  - Kept drag/hover/selection behavior intact.

## Testing / 测试
- `pnpm build` ✅
- Manual verification:
  - done/cancelled bars render lighter than active bars,
  - text remains readable,
  - hover/selection/drag interactions still behave normally.

## Risk & Rollback / 风险与回滚
- Risk: low, style-only change in gantt item rendering.
- 风险：低，仅涉及甘特条目样式。
- Rollback: revert this PR commit.
- 回滚：回退本 PR 提交即可。

Closes #10
